### PR TITLE
实现基于方法白名单的重试机制

### DIFF
--- a/version3/src/main/java/part2/Client/proxy/ClientProxy.java
+++ b/version3/src/main/java/part2/Client/proxy/ClientProxy.java
@@ -37,13 +37,12 @@ public class ClientProxy implements InvocationHandler {
                 .methodName(method.getName())
                 .params(args).paramsType(method.getParameterTypes()).build();
         //数据传输
-        RpcResponse response;
-        //后续添加逻辑：为保持幂等性，只对白名单上的服务进行重试
-        if (serviceCenter.checkRetry(request.getInterfaceName())){
-            //调用retry框架进行重试操作
-            response=new guavaRetry().sendServiceWithRetry(request,rpcClient);
-        }else {
-            //只调用一次
+        String methodSignature = getMethodSignature(request.getInterfaceName(), method);
+        System.out.println("方法签名: " + methodSignature);
+        RpcResponse response = null;
+        if(serviceCenter.checkRetry(methodSignature)){
+            response = new guavaRetry().sendServiceWithRetry(request, rpcClient);
+        } else {
             response= rpcClient.sendRequest(request);
         }
         return response.getData();
@@ -51,5 +50,20 @@ public class ClientProxy implements InvocationHandler {
      public <T>T getProxy(Class<T> clazz){
         Object o = Proxy.newProxyInstance(clazz.getClassLoader(), new Class[]{clazz}, this);
         return (T)o;
+    }
+    // 根据接口名字和方法获取方法签名
+    private String getMethodSignature(String interfaceName, Method method) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(interfaceName).append("#").append(method.getName()).append("(");
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            sb.append(parameterTypes[i].getName());
+            if (i < parameterTypes.length - 1) {
+                sb.append(",");
+            } else{
+                sb.append(")");
+            }
+        }
+        return sb.toString();
     }
 }

--- a/version3/src/main/java/part2/Client/retry/annotation/Retryable.java
+++ b/version3/src/main/java/part2/Client/retry/annotation/Retryable.java
@@ -1,0 +1,12 @@
+package part2.Client.retry.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Retryable {
+
+}

--- a/version3/src/main/java/part2/Client/serviceCenter/ZKServiceCenter.java
+++ b/version3/src/main/java/part2/Client/serviceCenter/ZKServiceCenter.java
@@ -64,20 +64,21 @@ public class ZKServiceCenter implements ServiceCenter{
         return null;
     }
     //
-    public boolean checkRetry(String serviceName) {
-        boolean canRetry =false;
+    @Override
+    public boolean checkRetry(String methodSignature) {
         try {
-            List<String> serviceList = client.getChildren().forPath("/" + RETRY);
-            for(String s:serviceList){
-                if(s.equals(serviceName)){
-                    System.out.println("服务"+serviceName+"在白名单上，可进行重试");
-                    canRetry=true;
+            CuratorFramework rootClient = client.usingNamespace(RETRY);
+            List<String> retryableMethods = rootClient.getChildren().forPath("/");
+            for(String s : retryableMethods){
+                if(s.equals(methodSignature)){
+                    System.out.println("方法" + methodSignature + "在白名单上，可进行重试");
+                    return true;
                 }
             }
-        }catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
-        return canRetry;
+        return false;
     }
     // 地址 -> XXX.XXX.XXX.XXX:port 字符串
     private String getServiceAddress(InetSocketAddress serverAddress) {

--- a/version3/src/main/java/part2/Server/provider/ServiceProvider.java
+++ b/version3/src/main/java/part2/Server/provider/ServiceProvider.java
@@ -36,7 +36,7 @@ public class ServiceProvider {
             //本机的映射表
             interfaceProvider.put(clazz.getName(),service);
             //在注册中心注册服务
-            serviceRegister.register(clazz.getName(),new InetSocketAddress(host,port),canRetry);
+            serviceRegister.register(clazz,new InetSocketAddress(host,port));
         }
     }
 

--- a/version3/src/main/java/part2/Server/serviceRegister/ServiceRegister.java
+++ b/version3/src/main/java/part2/Server/serviceRegister/ServiceRegister.java
@@ -10,6 +10,6 @@ import java.net.InetSocketAddress;
 // 服务注册接口
 public interface ServiceRegister {
     //  注册：保存服务与地址。
-    void register(String serviceName, InetSocketAddress serviceAddress,boolean canRetry);
+    void register(Class<?> clazz, InetSocketAddress serviceAddress);
 
 }

--- a/version3/src/main/java/part2/Server/serviceRegister/impl/ZKServiceRegister.java
+++ b/version3/src/main/java/part2/Server/serviceRegister/impl/ZKServiceRegister.java
@@ -5,9 +5,14 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
+import part2.Client.retry.annotation.Retryable;
 import part2.Server.serviceRegister.ServiceRegister;
 
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author wxx
  * @version 1.0
@@ -35,9 +40,10 @@ public class ZKServiceRegister implements ServiceRegister {
     }
     //注册服务到注册中心
     @Override
-    public void register(String serviceName, InetSocketAddress serviceAddress,boolean canRetry) {
+    public void register(Class<?> clazz, InetSocketAddress serviceAddress) {
         try {
             // serviceName创建成永久节点，服务提供者下线时，不删服务名，只删地址
+            String serviceName = clazz.getName();
             if(client.checkExists().forPath("/" + serviceName) == null){
                 client.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT).forPath("/" + serviceName);
             }
@@ -45,10 +51,12 @@ public class ZKServiceRegister implements ServiceRegister {
             String path = "/" + serviceName +"/"+ getServiceAddress(serviceAddress);
             // 临时节点，服务器下线就删除节点
             client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(path);
-            //如果这个服务是幂等性，就增加到节点中
-            if (canRetry){
-                path ="/"+RETRY+"/"+serviceName;
-                client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(path);
+            //将当前接口中所有幂等的方法增加到节点中
+            List<String> retryableMethods = getRetryableMethod(clazz);
+            System.out.println("可重试的方法: " + retryableMethods);
+            CuratorFramework rootClient = client.usingNamespace(RETRY);
+            for (String retryableMethod : retryableMethods) {
+                rootClient.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath("/" + retryableMethod);
             }
         } catch (Exception e) {
             System.out.println("此服务已存在");
@@ -64,5 +72,31 @@ public class ZKServiceRegister implements ServiceRegister {
     private InetSocketAddress parseAddress(String address) {
         String[] result = address.split(":");
         return new InetSocketAddress(result[0], Integer.parseInt(result[1]));
+    }
+    // 判断一个方法是否加了@Retryable注解
+    private List<String> getRetryableMethod(Class<?> clazz){
+        List<String> retryableMethods = new ArrayList<>();
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.isAnnotationPresent(Retryable.class)) {
+                String methodSignature = getMethodSignature(clazz, method);
+                retryableMethods.add(methodSignature);
+            }
+        }
+        return retryableMethods;
+    }
+    // 获取方法签名：接口名 + 方法名 + 方法参数类型
+    private String getMethodSignature(Class<?> clazz, Method method) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(clazz.getName()).append("#").append(method.getName()).append("(");
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            sb.append(parameterTypes[i].getName());
+            if (i < parameterTypes.length - 1) {
+                sb.append(",");
+            } else{
+                sb.append(")");
+            }
+        }
+        return sb.toString();
     }
 }

--- a/version3/src/main/java/part2/common/serializer/mySerializer/JsonSerializer.java
+++ b/version3/src/main/java/part2/common/serializer/mySerializer/JsonSerializer.java
@@ -45,7 +45,7 @@ public class JsonSerializer implements Serializer {
                 RpcResponse response = JSON.parseObject(bytes, RpcResponse.class);
                 Class<?> dataType = response.getDataType();
                 //判断转化后的response对象中的data的类型是否正确
-                if(! dataType.isAssignableFrom(response.getData().getClass())){
+                if(response.getData() != null && !dataType.isAssignableFrom(response.getData().getClass())){
                     response.setData(JSONObject.toJavaObject((JSONObject) response.getData(),dataType));
                 }
                 obj = response;

--- a/version3/src/main/java/part2/common/service/UserService.java
+++ b/version3/src/main/java/part2/common/service/UserService.java
@@ -1,6 +1,7 @@
 package part2.common.service;
 
 
+import part2.Client.retry.annotation.Retryable;
 import part2.common.pojo.User;
 
 /**
@@ -10,7 +11,10 @@ import part2.common.pojo.User;
  */
 public interface UserService {
     // 客户端通过这个接口调用服务端的实现类
+    @Retryable
     User getUserByUserId(Integer id);
+
     //新增一个功能
+    @Retryable
     Integer insertUserId(User user);
 }

--- a/version4/src/main/java/part1/Client/retry/annotation/Retryable.java
+++ b/version4/src/main/java/part1/Client/retry/annotation/Retryable.java
@@ -1,0 +1,12 @@
+package part1.Client.retry.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Retryable {
+
+}

--- a/version4/src/main/java/part1/Client/serviceCenter/ZKServiceCenter.java
+++ b/version4/src/main/java/part1/Client/serviceCenter/ZKServiceCenter.java
@@ -64,20 +64,21 @@ public class ZKServiceCenter implements ServiceCenter{
         return null;
     }
     //
-    public boolean checkRetry(String serviceName) {
-        boolean canRetry =false;
+    @Override
+    public boolean checkRetry(String methodSignature) {
         try {
-            List<String> serviceList = client.getChildren().forPath("/" + RETRY);
-            for(String s:serviceList){
-                if(s.equals(serviceName)){
-                    System.out.println("服务"+serviceName+"在白名单上，可进行重试");
-                    canRetry=true;
+            CuratorFramework rootClient = client.usingNamespace(RETRY);
+            List<String> retryableMethods = rootClient.getChildren().forPath("/");
+            for(String s : retryableMethods){
+                if(s.equals(methodSignature)){
+                    System.out.println("方法" + methodSignature + "在白名单上，可进行重试");
+                    return true;
                 }
             }
-        }catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
-        return canRetry;
+        return false;
     }
     // 地址 -> XXX.XXX.XXX.XXX:port 字符串
     private String getServiceAddress(InetSocketAddress serverAddress) {

--- a/version4/src/main/java/part1/Server/provider/ServiceProvider.java
+++ b/version4/src/main/java/part1/Server/provider/ServiceProvider.java
@@ -39,7 +39,7 @@ public class ServiceProvider {
             //本机的映射表
             interfaceProvider.put(clazz.getName(),service);
             //在注册中心注册服务
-            serviceRegister.register(clazz.getName(),new InetSocketAddress(host,port),canRetry);
+            serviceRegister.register(clazz,new InetSocketAddress(host,port));
         }
     }
 

--- a/version4/src/main/java/part1/Server/serviceRegister/ServiceRegister.java
+++ b/version4/src/main/java/part1/Server/serviceRegister/ServiceRegister.java
@@ -10,6 +10,6 @@ import java.net.InetSocketAddress;
 // 服务注册接口
 public interface ServiceRegister {
     //  注册：保存服务与地址。
-    void register(String serviceName, InetSocketAddress serviceAddress,boolean canRetry);
+    void register(Class<?> clazz, InetSocketAddress serviceAddress);
 
 }

--- a/version4/src/main/java/part1/Server/serviceRegister/impl/ZKServiceRegister.java
+++ b/version4/src/main/java/part1/Server/serviceRegister/impl/ZKServiceRegister.java
@@ -5,9 +5,14 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
+import part1.Client.retry.annotation.Retryable;
 import part1.Server.serviceRegister.ServiceRegister;
 
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author wxx
  * @version 1.0
@@ -35,9 +40,10 @@ public class ZKServiceRegister implements ServiceRegister {
     }
     //注册服务到注册中心
     @Override
-    public void register(String serviceName, InetSocketAddress serviceAddress,boolean canRetry) {
+    public void register(Class<?> clazz, InetSocketAddress serviceAddress) {
         try {
             // serviceName创建成永久节点，服务提供者下线时，不删服务名，只删地址
+            String serviceName = clazz.getName();
             if(client.checkExists().forPath("/" + serviceName) == null){
                 client.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT).forPath("/" + serviceName);
             }
@@ -45,10 +51,12 @@ public class ZKServiceRegister implements ServiceRegister {
             String path = "/" + serviceName +"/"+ getServiceAddress(serviceAddress);
             // 临时节点，服务器下线就删除节点
             client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(path);
-            //如果这个服务是幂等性，就增加到节点中
-            if (canRetry){
-                path ="/"+RETRY+"/"+serviceName;
-                client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(path);
+            //将当前接口中所有幂等的方法增加到节点中
+            List<String> retryableMethods = getRetryableMethod(clazz);
+            System.out.println("可重试的方法: " + retryableMethods);
+            CuratorFramework rootClient = client.usingNamespace(RETRY);
+            for (String retryableMethod : retryableMethods) {
+                rootClient.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath("/" + retryableMethod);
             }
         } catch (Exception e) {
             System.out.println("此服务已存在");
@@ -64,5 +72,31 @@ public class ZKServiceRegister implements ServiceRegister {
     private InetSocketAddress parseAddress(String address) {
         String[] result = address.split(":");
         return new InetSocketAddress(result[0], Integer.parseInt(result[1]));
+    }
+    // 判断一个方法是否加了@Retryable注解
+    private List<String> getRetryableMethod(Class<?> clazz){
+        List<String> retryableMethods = new ArrayList<>();
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.isAnnotationPresent(Retryable.class)) {
+                String methodSignature = getMethodSignature(clazz, method);
+                retryableMethods.add(methodSignature);
+            }
+        }
+        return retryableMethods;
+    }
+    // 获取方法签名：接口名 + 方法名 + 方法参数类型
+    private String getMethodSignature(Class<?> clazz, Method method) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(clazz.getName()).append("#").append(method.getName()).append("(");
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            sb.append(parameterTypes[i].getName());
+            if (i < parameterTypes.length - 1) {
+                sb.append(",");
+            } else{
+                sb.append(")");
+            }
+        }
+        return sb.toString();
     }
 }

--- a/version4/src/main/java/part1/common/serializer/mySerializer/JsonSerializer.java
+++ b/version4/src/main/java/part1/common/serializer/mySerializer/JsonSerializer.java
@@ -50,7 +50,7 @@ public class JsonSerializer implements Serializer {
                 }
                 Class<?> dataType = response.getDataType();
                 //判断转化后的response对象中的data的类型是否正确
-                if(!dataType.isAssignableFrom(response.getData().getClass())){
+                if(response.getData() != null && !dataType.isAssignableFrom(response.getData().getClass())){
                     response.setData(JSONObject.toJavaObject((JSONObject) response.getData(),dataType));
                 }
                 obj = response;

--- a/version4/src/main/java/part1/common/service/UserService.java
+++ b/version4/src/main/java/part1/common/service/UserService.java
@@ -1,6 +1,7 @@
 package part1.common.service;
 
 
+import part1.Client.retry.annotation.Retryable;
 import part1.common.pojo.User;
 
 /**
@@ -10,7 +11,10 @@ import part1.common.pojo.User;
  */
 public interface UserService {
     // 客户端通过这个接口调用服务端的实现类
+    @Retryable
     User getUserByUserId(Integer id);
+
     //新增一个功能
+    @Retryable
     Integer insertUserId(User user);
 }

--- a/version5/krpc-api/src/main/java/com/kama/annotation/Retryable.java
+++ b/version5/krpc-api/src/main/java/com/kama/annotation/Retryable.java
@@ -1,0 +1,12 @@
+package com.kama.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Retryable {
+
+}

--- a/version5/krpc-api/src/main/java/com/kama/service/UserService.java
+++ b/version5/krpc-api/src/main/java/com/kama/service/UserService.java
@@ -1,6 +1,7 @@
 package com.kama.service;
 
 
+import com.kama.annotation.Retryable;
 import com.kama.pojo.User;
 
 /**
@@ -13,7 +14,10 @@ import com.kama.pojo.User;
 
 public interface UserService {
     // 查询
+    @Retryable
     User getUserByUserId(Integer id);
+
     // 新增
+    @Retryable
     Integer insertUserId(User user);
 }

--- a/version5/krpc-common/src/main/java/common/serializer/myserializer/JsonSerializer.java
+++ b/version5/krpc-common/src/main/java/common/serializer/myserializer/JsonSerializer.java
@@ -53,7 +53,7 @@ public class JsonSerializer implements Serializer {
                 }
                 Class<?> dataType = response.getDataType();
                 //判断转化后的response对象中的data的类型是否正确
-                if(!dataType.isAssignableFrom(response.getData().getClass())){
+                if(response.getData() != null && !dataType.isAssignableFrom(response.getData().getClass())){
                     response.setData(JSONObject.toJavaObject((JSONObject) response.getData(),dataType));
                 }
                 obj = response;

--- a/version5/krpc-core/src/main/java/com/kama/server/provider/ServiceProvider.java
+++ b/version5/krpc-core/src/main/java/com/kama/server/provider/ServiceProvider.java
@@ -46,7 +46,7 @@ public class ServiceProvider {
             //本机的映射表
             interfaceProvider.put(clazz.getName(), service);
             //在注册中心注册服务
-            serviceRegister.register(clazz.getName(), new InetSocketAddress(host, port), canRetry);
+            serviceRegister.register(clazz, new InetSocketAddress(host, port));
         }
     }
 

--- a/version5/krpc-core/src/main/java/com/kama/server/serviceRegister/ServiceRegister.java
+++ b/version5/krpc-core/src/main/java/com/kama/server/serviceRegister/ServiceRegister.java
@@ -12,5 +12,5 @@ import java.net.InetSocketAddress;
  */
 
 public interface ServiceRegister {
-    void register(String serviceName, InetSocketAddress serviceAddress, boolean canRetry);
+    void register(Class<?> clazz, InetSocketAddress serviceAddress);
 }


### PR DESCRIPTION
## 具体改进：
之前的白名单机制是基于接口实现的，但一个接口往往包含多个方法，而这些方法的幂等性可能各不相同。因此，实现了基于更细粒度的方法建立白名单，并根据白名单判断是否开启重试机制。

通过定义自定义注解 `@Retryable`，可以直接将注解添加在 `XXXService` 接口中的幂等方法上。注册服务时，程序会扫描接口中所有标注了 `@Retryable` 的方法，通过 接口名 + 方法名 + 方法参数类型列表 唯一确定每个方法，并将这些方法注册为 ZooKeeper中的节点。

在发送请求时，客户端会动态从ZooKeeper中读取注册过的方法作为白名单判断当前方法是否允许重试，从而决定是否开启重试机制。

（有个疑问，就是这里如果是非幂等的方法调用失败返回异常，不需要进行回滚吗？是因为RPC本身不负责回滚，回滚是由分布式事务控制的吗？）

## 测试结果：
1. 添加注解
![image](https://github.com/user-attachments/assets/061f029a-5dd1-46bd-98be-5781880bbb32)

2. 控制台输出
![image](https://github.com/user-attachments/assets/8aaff351-5512-4faf-855a-e3f7ed24848a)
![image](https://github.com/user-attachments/assets/d612f137-9d98-45b7-917c-971242820abc)

3. 查看ZooKeeper注册中心
![image](https://github.com/user-attachments/assets/1eba6936-eb90-4b76-8253-27d6cb9f22bc)
