### PR TITLE
实现基于方法白名单的重试机制

### DIFF
--- a/version5/krpc-api/src/main/java/com/kama/annotation/Retryable.java
+++ b/version5/krpc-api/src/main/java/com/kama/annotation/Retryable.java
@@ -1,0 +1,13 @@
+package com.kama.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Retryable {
+
+}
+

--- a/version5/krpc-api/src/main/java/com/kama/service/UserService.java
+++ b/version5/krpc-api/src/main/java/com/kama/service/UserService.java
@@ -1,6 +1,7 @@
 package com.kama.service;
 
 
+import com.kama.annotation.Retryable;
 import com.kama.pojo.User;
 
 /**
@@ -12,8 +13,12 @@ import com.kama.pojo.User;
  */
 
 public interface UserService {
+
     // 查询
+    @Retryable
     User getUserByUserId(Integer id);
+
     // 新增
+    @Retryable
     Integer insertUserId(User user);
 }

--- a/version5/krpc-common/src/main/java/common/serializer/myserializer/JsonSerializer.java
+++ b/version5/krpc-common/src/main/java/common/serializer/myserializer/JsonSerializer.java
@@ -53,7 +53,7 @@ public class JsonSerializer implements Serializer {
                 }
                 Class<?> dataType = response.getDataType();
                 //判断转化后的response对象中的data的类型是否正确
-                if(!dataType.isAssignableFrom(response.getData().getClass())){
+                if(response.getData() != null && !dataType.isAssignableFrom(response.getData().getClass())){
                     response.setData(JSONObject.toJavaObject((JSONObject) response.getData(),dataType));
                 }
                 obj = response;

--- a/version5/krpc-core/src/main/java/com/kama/client/rpcclient/impl/NettyRpcClient.java
+++ b/version5/krpc-core/src/main/java/com/kama/client/rpcclient/impl/NettyRpcClient.java
@@ -31,10 +31,10 @@ public class NettyRpcClient implements RpcClient {
     private static final Bootstrap bootstrap;
     private static final EventLoopGroup eventLoopGroup;
 
-    private ServiceCenter serviceCenter;
+    private final InetSocketAddress address;
 
-    public NettyRpcClient(ServiceCenter serviceCenter) throws InterruptedException {
-        this.serviceCenter = serviceCenter;
+    public NettyRpcClient(InetSocketAddress serviceAddress) {
+        this.address = serviceAddress;
     }
 
     //netty客户端初始化
@@ -48,7 +48,6 @@ public class NettyRpcClient implements RpcClient {
     @Override
     public RpcResponse sendRequest(RpcRequest request) {
         //从注册中心获取host,post
-        InetSocketAddress address = serviceCenter.serviceDiscovery(request.getInterfaceName());
         if (address == null) {
             log.error("服务发现失败，返回的地址为 null");
             return RpcResponse.fail("服务发现失败，地址为 null");

--- a/version5/krpc-core/src/main/java/com/kama/client/servicecenter/ServiceCenter.java
+++ b/version5/krpc-core/src/main/java/com/kama/client/servicecenter/ServiceCenter.java
@@ -1,6 +1,8 @@
 package com.kama.client.servicecenter;
 
 
+import common.message.RpcRequest;
+
 import java.net.InetSocketAddress;
 
 /**
@@ -13,8 +15,8 @@ import java.net.InetSocketAddress;
 
 public interface ServiceCenter {
     //  查询：根据服务名查找地址
-    InetSocketAddress serviceDiscovery(String serviceName);
+    InetSocketAddress serviceDiscovery(RpcRequest request);
 
     //判断是否可重试
-    boolean checkRetry(String serviceName);
+    boolean checkRetry(InetSocketAddress serviceAddress, String methodSignature);
 }

--- a/version5/krpc-core/src/main/java/com/kama/server/provider/ServiceProvider.java
+++ b/version5/krpc-core/src/main/java/com/kama/server/provider/ServiceProvider.java
@@ -38,7 +38,7 @@ public class ServiceProvider {
         this.rateLimitProvider = new RateLimitProvider();
     }
 
-    public void provideServiceInterface(Object service, boolean canRetry) {
+    public void provideServiceInterface(Object service) {
         String serviceName = service.getClass().getName();
         Class<?>[] interfaceName = service.getClass().getInterfaces();
 
@@ -46,7 +46,7 @@ public class ServiceProvider {
             //本机的映射表
             interfaceProvider.put(clazz.getName(), service);
             //在注册中心注册服务
-            serviceRegister.register(clazz.getName(), new InetSocketAddress(host, port), canRetry);
+            serviceRegister.register(clazz, new InetSocketAddress(host, port));
         }
     }
 

--- a/version5/krpc-core/src/main/java/com/kama/server/serviceRegister/ServiceRegister.java
+++ b/version5/krpc-core/src/main/java/com/kama/server/serviceRegister/ServiceRegister.java
@@ -12,5 +12,5 @@ import java.net.InetSocketAddress;
  */
 
 public interface ServiceRegister {
-    void register(String serviceName, InetSocketAddress serviceAddress, boolean canRetry);
+    void register(Class<?> clazz, InetSocketAddress serviceAddress);
 }

--- a/version5/krpc-core/src/main/java/com/kama/server/serviceRegister/impl/ZKServiceRegister.java
+++ b/version5/krpc-core/src/main/java/com/kama/server/serviceRegister/impl/ZKServiceRegister.java
@@ -1,5 +1,6 @@
 package com.kama.server.serviceRegister.impl;
 
+import com.kama.annotation.Retryable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
@@ -10,7 +11,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.kama.server.serviceRegister.ServiceRegister;
 
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @ClassName ZKServiceRegister
@@ -38,7 +42,8 @@ public class ZKServiceRegister implements ServiceRegister {
     }
 
     @Override
-    public void register(String serviceName, InetSocketAddress serviceAddress, boolean canRetry) {
+    public void register(Class<?> clazz, InetSocketAddress serviceAddress) {
+        String serviceName = clazz.getName();
         try {
             if (client.checkExists().forPath("/" + serviceName) == null) {
                 client.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT).forPath("/" + serviceName);
@@ -53,10 +58,12 @@ public class ZKServiceRegister implements ServiceRegister {
                 log.info("服务地址 {} 已经存在，跳过注册", path);
             }
 
-            if (canRetry) {
-                path = "/" + RETRY + "/" + serviceName;
-                client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(path);
-                log.info("重试标识 {} 注册成功", path);
+            // 注册白名单
+            List<String> retryableMethods = getRetryableMethod(clazz);
+            log.info("可重试的方法: {}", retryableMethods);
+            CuratorFramework rootClient = client.usingNamespace(RETRY);
+            for (String retryableMethod : retryableMethods) {
+                rootClient.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath("/" + getServiceAddress(serviceAddress) + "/" + retryableMethod);
             }
         } catch (Exception e) {
             log.error("服务注册失败，服务名：{}，错误信息：{}", serviceName, e.getMessage(), e);
@@ -70,5 +77,32 @@ public class ZKServiceRegister implements ServiceRegister {
 
     private String getServiceAddress(InetSocketAddress serverAddress) {
         return serverAddress.getHostName() + ":" + serverAddress.getPort();
+    }
+
+    // 判断一个方法是否加了Retryable注解
+    private List<String> getRetryableMethod(Class<?> clazz){
+        List<String> retryableMethods = new ArrayList<>();
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.isAnnotationPresent(Retryable.class)) {
+                String methodSignature = getMethodSignature(clazz, method);
+                retryableMethods.add(methodSignature);
+            }
+        }
+        return retryableMethods;
+    }
+
+    private String getMethodSignature(Class<?> clazz, Method method) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(clazz.getName()).append("#").append(method.getName()).append("(");
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            sb.append(parameterTypes[i].getName());
+            if (i < parameterTypes.length - 1) {
+                sb.append(",");
+            } else{
+                sb.append(")");
+            }
+        }
+        return sb.toString();
     }
 }

--- a/version5/krpc-provider/src/main/java/com/kama/provider/ProviderTest.java
+++ b/version5/krpc-provider/src/main/java/com/kama/provider/ProviderTest.java
@@ -20,16 +20,18 @@ public class ProviderTest {
 
     public static void main(String[] args) throws InterruptedException {
         KRpcApplication.initialize();
+        String ip = System.getProperty("ip");
+        int port = Integer.parseInt(System.getProperty("port"));
         // 创建 UserService 实例
         UserService userService = new UserServiceImpl();
-        ServiceProvider serviceProvider = new ServiceProvider("127.0.0.1", 9999);
+        ServiceProvider serviceProvider = new ServiceProvider(ip, port);
         // 发布服务接口到 ServiceProvider
-        serviceProvider.provideServiceInterface(userService, true);  // 可以设置是否支持重试
+        serviceProvider.provideServiceInterface(userService);  // 可以设置是否支持重试
 
         // 启动 RPC 服务器并监听端口
         RpcServer rpcServer = new NettyRpcServer(serviceProvider);
-        rpcServer.start(9999);  // 启动 Netty RPC 服务，监听 9999 端口
-        log.info("RPC 服务端启动，监听端口 9999");
+        rpcServer.start(port);  // 启动 Netty RPC 服务，监听 port 端口
+        log.info("RPC 服务端启动，监听端口" + port);
     }
 
 }


### PR DESCRIPTION
## 具体改进：
之前的白名单机制是基于接口实现的，但一个接口往往包含多个方法，而这些方法的幂等性可能各不相同。因此，实现了基于更细粒度的方法建立白名单，并根据白名单判断是否开启重试机制。

通过定义自定义注解 `@Retryable`，可以直接将注解添加在 `XXXService` 接口中的幂等方法上。注册服务时，程序会扫描接口中所有标注了 `@Retryable` 的方法，通过 接口名 + 方法名 + 方法参数类型列表 唯一确定每个方法，并将这些方法注册为 ZooKeeper中的节点。

在发送请求时，客户端会动态从ZooKeeper中读取注册过的方法作为白名单判断当前方法是否允许重试，从而决定是否开启重试机制。

（我只修改了version5部分）

## 测试结果：
1. 添加注解
![image](https://github.com/user-attachments/assets/061f029a-5dd1-46bd-98be-5781880bbb32)

2. 控制台输出
![image](https://github.com/user-attachments/assets/77618be5-3b20-472b-9daf-4a54b22fe70a)
![image](https://github.com/user-attachments/assets/c0171568-9997-49a2-977d-57da23499e7e)



3. 查看ZooKeeper注册中心
![image](https://github.com/user-attachments/assets/57d63981-f997-46bf-bb29-7cc4ebe602cf)

